### PR TITLE
added section on tracebacks

### DIFF
--- a/except_star.md
+++ b/except_star.md
@@ -518,7 +518,7 @@ assigned to the `__traceback__` field of an exception.
 Instead of a single `tb_next` link to a single traceback, the
 `TracebackGroup` has a `tb_next_map` that maps each exception from the
 `ExceptionGroup` to a traceback. This map holds weak references to
-it keys so that it does not prevent GC exceptions.
+its keys so that it does not prevent GC of exceptions.
 
 
 **Appending a frame** `f` to the end of the traceback of an exception `eg`

--- a/except_star.md
+++ b/except_star.md
@@ -488,14 +488,14 @@ We can consider allowing some of them in future versions of Python.
 For regular exceptions, the traceback represents a simple path of frames,
 from the frame in which the exception was raised to the frame in which it was
 was caught or, if it hasn't been caught yet, the frame that the program's
-execution is currently in. The list is constructed by the interpreter which
-appends a frame to the traceback of the 'current exception' (the one returned
-by `sys.exc_info()`) if one exists. To support efficient appends, the links
-in a traceback's list of frames are from the oldest to the newest frame.
+execution is currently in. The list is constructed by the interpreter which,
+appends any frame it exits to the traceback of the 'current exception' if one
+exists (the exception returned by `sys.exc_info()`). To support efficient appends,
+the links in a traceback's list of frames are from the oldest to the newest frame.
 Appending a new frame is then simply a matter of inserting a new head to the
 linked list referenced from the exception's `__traceback__` field. Crucially,
-the traceback is immutable in the sense that once frames are added they are
-no longer modified.
+the traceback's frame list is immutable in the sense that frames only need to
+be added at the head, and never need to be removed.
 
 We will not need to make any changes to this data structure. The
 `__traceback__` field of the ExceptionGroup object represents that path that
@@ -503,7 +503,7 @@ the exceptions travelled through together after being joined into the
 ExceptionGroup, and the same field on each of the nested exceptions represents
 that path through which each exception arrived to the frame of the merge.
 
-What we will need to change is code that interprets and displays tracebacks,
+What we do need to change is any code that interprets and displays tracebacks,
 because it will now need to continue into tracebacks of nested exceptions
 once the traceback of an ExceptionGroup has been processed.
 

--- a/except_star.md
+++ b/except_star.md
@@ -503,7 +503,7 @@ the exceptions travelled through together after being joined into the
 ExceptionGroup, and the same field on each of the nested exceptions represents
 that path through which each exception arrived to the frame of the merge.
 
-What we will need to change it code that interprets and displays tracebacks,
+What we will need to change is code that interprets and displays tracebacks,
 because it will now need to continue into tracebacks of nested exceptions
 once the traceback of an ExceptionGroup has been processed.
 
@@ -666,6 +666,16 @@ to start using the new `except *` syntax right away.  They will have to use
 the new ExceptionGroup low-level APIs along with `try..except ExceptionGroup`
 to support running user code that can raise exception groups.
 
+### Traceback Representation
+
+We considered options for adapting the traceback data structure to represent
+trees, but it became aparent that a traceback tree is not meaninful once separated
+from the exceptions it refers to. While a simple-path traceback can be attached to
+any exception by a `with_traceback()` call, it is hard to imagine a case where it
+makes sense to assign a traceback tree to an exception group.  Furthermore, a
+useful display of the traceback includes information about the nested exceptions.
+For this reason we decided it is best to leave the traceback mechanism as it is
+and modify the traceback display code.
 
 ## See Also
 

--- a/except_star.md
+++ b/except_star.md
@@ -483,6 +483,99 @@ errors is error prone.
 
 We can consider allowing some of them in future versions of Python.
 
+## Traceback Groups
+
+For regular exceptions, the traceback represents a simple path of frames, from
+the frame in which the exception was raised to the frame in which it was
+was caught or, if it hasn't been caught yet, the frame that the program's
+execution is currently in.
+At any point in time the interpreter has at most one 'current exception' (the
+one returned by `sys.exc_info()`), and as execution progresses, it is
+necessary to append frames to this exception's traceback. Therefore the
+traceback's list of frames is stored in reverse order, such that the `next`
+links lead from the last frame to the first. Appending a new frame is then
+simply a matter of inserting a new head to the linked list referenced from
+the exception's `__traceback__` field.
+
+When we add `ExceptionGroup`s, the traceback becomes a tree of frames: each
+exception has a traceback that describes the path from where it was raised
+to where it was first added to an `ExceptionGroup`. From that point, all
+exceptions in the same group travel through the same frames, possibly
+merging with other exceptions into larger `ExceptionGroup`s. In this section
+we describe the `TracebackGroup` data structure which we are proposing to
+represent the tracebacks of the exceptions in an `ExceptionGroup`.
+
+`TracebackGroup`s satisfy the following requirements:
+1. Supports appending a frame in O(1) time.
+2. Supports efficient insertions and deletions of tracebacks as the
+exception group grows and splits.
+3. Does not hold references that can prevent GC of exceptions from the group.
+4. Does not require API breaking changes to the current traceback
+representation for regular exceptions.
+
+The `TracebackGroup` type is a subclass of `Traceback` and therefore can be
+assigned to the `__traceback__` field of an exception.
+Instead of a single `tb_next` link to a single traceback, the
+`TracebackGroup` has a `tb_next_map` that maps each exception from the
+`ExceptionGroup` to a traceback. This map holds weak references to
+it keys so that it does not prevent GC exceptions.
+
+
+**Appending a frame** `f` to the end of the traceback of an exception `eg`
+is exactly the same as for traceback groups and regular tracebacks:
+
+```python
+tb = Traceback(tb_frame = f, tb_next = eg.__traceback__)
+eg.__traceback__ = tb
+```
+
+**Adding an exception** `e` to the `ExceptionGroup eg` requires adding its
+exception(s) to `tb_next_map` of `eg`:
+
+```python
+if not isinstance(e, ExceptionGroup):
+    keys = [e]                               # e is a simple exception
+else:
+    keys = list(e.tb_next_map.keys())        # e is an ExceptionGroup
+
+for k in keys:
+    if not isinstance(eg.__traceback__, TracebackGroup):
+        # simple traceback, convert it to a group    (WILL WE EVER NEED THIS?)
+        eg.__traceback__ = TracebackGroup.fromTraceback(eg.__traceback__)
+    eg.__traceback__.tb_next_map[weakref(k)] = e.__traceback__
+```
+
+To **remove** an exception from an `ExceptionGroup` we do the reverse: we
+remove this exception from all `tb_next_map`s on its traceback path (there
+may be more than one `tb_next_map` that have this exception in its keys if
+the `ExceptionGroup` is nested):
+
+```python
+tb = e.__traceback__
+while tb:
+    if isintance(tb, TracebackGroup):
+        next = tb.tb_next_map[e]
+        del tb.tb_next_map[e]
+        tb = next
+    else:
+        tb = tb.tb_next
+```
+
+
+To **split out a subset** of the exceptions in an `ExceptionGroup` that
+match a certain except* clause, we create a new empty `ExceptionGroup`,
+and then perform a sequence of deletions from the original group and
+insertions into the new group. These operations update the tracebacks
+as well:
+
+```python
+def split(eg, type):
+    matches = [e in eg if isinstance(e, type)]
+    for m in matches:
+        eg.remove(m)
+    return ExceptionGroup(matches)
+```
+
 ## Design Considerations
 
 ### Why try..except* syntax

--- a/except_star.md
+++ b/except_star.md
@@ -669,7 +669,7 @@ to support running user code that can raise exception groups.
 ### Traceback Representation
 
 We considered options for adapting the traceback data structure to represent
-trees, but it became aparent that a traceback tree is not meaninful once separated
+trees, but it became apparent that a traceback tree is not meaningful once separated
 from the exceptions it refers to. While a simple-path traceback can be attached to
 any exception by a `with_traceback()` call, it is hard to imagine a case where it
 makes sense to assign a traceback tree to an exception group.  Furthermore, a


### PR DESCRIPTION
Added a section on traceback groups.

I assume there will be a section on exception group API before it, so the reference to splitting operations etc make sense. 

We'll need some pictures of trees. 
