### PR TITLE
Towards pep

### DIFF
--- a/except_star.md
+++ b/except_star.md
@@ -58,7 +58,7 @@ so it is assignable to `Exception.__cause__` and `Exception.__context__`, and ca
 be raised and handled as any exception with `raise ExceptionGroup(...)` and
 `try: ... except ExceptionGroup: ...`.
 
-Its constructor takes two parameters: a message string and a sequence of the nested
+Its constructor takes two positional-only parameters: a message string and a sequence of the nested
 exceptions, for example:
 `ExceptionGroup('many problems', [ValueError('bad value'), TypeError('bad type')])`.
 

--- a/except_star.md
+++ b/except_star.md
@@ -119,7 +119,7 @@ it is checked with `isinstance` rather than being treated as a callable.
 For regular exceptions, the traceback represents a simple path of frames,
 from the frame in which the exception was raised to the frame in which it was
 was caught or, if it hasn't been caught yet, the frame that the program's
-execution is currently in. The list is constructed by the interpreter which,
+execution is currently in. The list is constructed by the interpreter, which
 appends any frame from which it exits to the traceback of the 'current
 exception' if one exists (the exception returned by `sys.exc_info()`). To
 support efficient appends, the links in a traceback's list of frames are from

--- a/except_star.md
+++ b/except_star.md
@@ -73,8 +73,8 @@ a subset of the exceptions that satify a certain condition:
 ```python
 eg = ExceptionGroup("one",
                     [TypeError(1),
-                    ExceptionGroup("two",
-                                   [TypeError(2), ValueError(3)]])
+                     ExceptionGroup("two",
+                                    [TypeError(2), ValueError(3)]])
 
 match, rest = eg.split(lambda e: isinstance(e, TypeError))
 ```

--- a/except_star.md
+++ b/except_star.md
@@ -835,7 +835,7 @@ a cleanup.
 
 [An experimental implementation](https://github.com/iritkatriel/cpython/tree/exceptionGroup-stage4).
 
-(raise in except* not supported yet).
+(`raise` in `except*` not supported yet).
 
 ## Rejected Ideas
 

--- a/except_star.md
+++ b/except_star.md
@@ -45,7 +45,7 @@ for user code to inadvertently swallow exceptions that it is not handling.
 The purpose of this PEP, then, is to add the `except*` syntax for handling `ExceptionGroups`s in
 the interpreter, which in turn requires that `ExceptionGroup` is added as a builtin type. The
 semantics of handling `ExceptionGroup`s are not backwards compatible with the current exception
-handling semantics, so could not modify the behaviour of the `except` keyword and instead added
+handling semantics, so we could not modify the behaviour of the `except` keyword and instead added
 the new `except*` syntax.
 
 

--- a/except_star.md
+++ b/except_star.md
@@ -26,7 +26,7 @@ as the stack unwinds. Several real world use cases are listed below.
 
 * Situations where multiple unrelated exceptiion may be of interest to calling code [https://bugs.python.org/issue40857]
 
-* Multiple teardowsn in pytest raising exceptions [https://github.com/pytest-dev/pytest/issues/8217]
+* Multiple teardowns in pytest raising exceptions [https://github.com/pytest-dev/pytest/issues/8217]
 
 ## Rationale
 

--- a/except_star.md
+++ b/except_star.md
@@ -885,11 +885,22 @@ be attached to any exception by a `with_traceback()` call, it is hard to
 imagine a case where it makes sense to assign a traceback tree to an exception
 group.  Furthermore, a useful display of the traceback includes information
 about the nested exceptions. For this reason we decided it is best to leave
-the traceback mechanism as it is
-and modify the traceback display code.
+the traceback mechanism as it is and modify the traceback display code.
+
+### A full redesign of `except`
+
+We considered introducing a new keyword (such as `catch`) which can be used
+to handle both plain exceptions and `ExceptionGroup`s. Its semantics would
+be the same as those of `except*` when catching an `ExceptionGroup`, but
+it would not wrap plain a exception to create an `ExceptionGroup`. This
+would have been part of a long term plan to replace `except` by `catch`,
+but we decided that deprecating `except` in favour of an improved keyword
+is too hard at this time, and it is more realistic to introduce the
+`except*` syntax for `ExceptionGroup`s while `except` continues to be
+used for simple exceptions.
 
 
-### Adoption of try..except* syntax
+## Adoption of try..except* syntax
 
 Application code typically can dictate what version of Python it requires.
 Which makes introducing TaskGroups and the new `except *` clause somewhat

--- a/except_star.md
+++ b/except_star.md
@@ -894,10 +894,10 @@ to handle both plain exceptions and `ExceptionGroup`s. Its semantics would
 be the same as those of `except*` when catching an `ExceptionGroup`, but
 it would not wrap plain a exception to create an `ExceptionGroup`. This
 would have been part of a long term plan to replace `except` by `catch`,
-but we decided that deprecating `except` in favour of an improved keyword
-is too hard at this time, and it is more realistic to introduce the
-`except*` syntax for `ExceptionGroup`s while `except` continues to be
-used for simple exceptions.
+but we decided that deprecating `except` in favour of an enhanced keyword
+would be too confusing for users at this time, so it is more appropriate
+to introduce the `except*` syntax for `ExceptionGroup`s while `except`
+continues to be used for simple exceptions.
 
 
 ## Adoption of try..except* syntax


### PR DESCRIPTION

I'm assuming that we're going towards a single PEP for ExceptionGroups and except*, so this PR adds the missing section about ExceptionGroups.   I also tried to add some of the intro sections, and arrange it closer to the PEP12 headings. 

